### PR TITLE
Strip newlines from divider outputs

### DIFF
--- a/area4/__init__.py
+++ b/area4/__init__.py
@@ -45,7 +45,7 @@ def divider(number):
         raise ValueError('Please use a number bigger then 0!')
     else:
         try:
-            return theArray()[number]
+            return theArray()[number].replace("\n", "n")
         except IndexError:
             raise ValueError('That divider does not exist!')
 

--- a/area4/__init__.py
+++ b/area4/__init__.py
@@ -45,7 +45,7 @@ def divider(number):
         raise ValueError('Please use a number bigger then 0!')
     else:
         try:
-            return theArray()[number].replace("\n", "n")
+            return theArray()[number].replace("\n", "")
         except IndexError:
             raise ValueError('That divider does not exist!')
 

--- a/area4/util.py
+++ b/area4/util.py
@@ -23,7 +23,9 @@ def get_raw_file():
         )
     ), mode="r") as file_handler:
         lines = file_handler.readlines()
-        lines[35] = random.randint(0, 999999999999)
+        lines[35] = str(
+            random.randint(0, 999999999999)
+        )
         return lines
 
 

--- a/tests.py
+++ b/tests.py
@@ -51,7 +51,7 @@ class TestCode(unittest.TestCase):
                 if i != 35 and i != 0:
                     self.assertEqual(self.raw_dividers[i].replace("\n", ""), area4.divider(i))
                 elif i == 35 and i != 0:
-                    self.assertNotEqual(self.raw_dividers[i].replace("\n", ""), area4.divider(i))
+                    self.assertNotEqual(self.raw_dividers[i], area4.divider(i))
             finally:
                 print()
 

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,7 @@ class TestCode(unittest.TestCase):
                 # Try to match the raw divider with the result
                 # of the function:
                 if i != 35 and i != 0:
-                    self.assertEqual(self.raw_dividers[i], area4.divider(i))
+                    self.assertEqual(self.raw_dividers[i].replace("\n", ""), area4.divider(i))
                 elif i == 35 and i != 0:
                     self.assertNotEqual(self.raw_dividers[i], area4.divider(i))
             finally:

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,10 @@ class TestCode(unittest.TestCase):
                 # Try to match the raw divider with the result
                 # of the function:
                 if i != 35 and i != 0:
-                    self.assertEqual(self.raw_dividers[i].replace("\n", ""), area4.divider(i))
+                    self.assertEqual(
+                       self.raw_dividers[i].replace("\n", ""),
+                       area4.divider(i)
+                    )
                 elif i == 35 and i != 0:
                     self.assertNotEqual(self.raw_dividers[i], area4.divider(i))
             finally:

--- a/tests.py
+++ b/tests.py
@@ -51,7 +51,7 @@ class TestCode(unittest.TestCase):
                 if i != 35 and i != 0:
                     self.assertEqual(self.raw_dividers[i].replace("\n", ""), area4.divider(i))
                 elif i == 35 and i != 0:
-                    self.assertNotEqual(self.raw_dividers[i], area4.divider(i))
+                    self.assertNotEqual(self.raw_dividers[i].replace("\n", ""), area4.divider(i))
             finally:
                 print()
 


### PR DESCRIPTION
## Description

Stop the ```\n``` from being returned when ```area4.divider``` is called.
## Context

This pull req fixes: [this issue](https://github.com/area4lib/area4/issues/184)